### PR TITLE
Fix memory leak in radTSend::OutRelaxResultsInfo

### DIFF
--- a/cpp/src/core/radsend.cpp
+++ b/cpp/src/core/radsend.cpp
@@ -1957,15 +1957,15 @@ void radTSend::OutRelaxResultsInfo(double* RelaxStatusParamArray, int lenRelaxSt
 //#ifdef __JAVA__
 #if defined __JAVA__ || defined ALPHA__DLL__ || defined ALPHA__LIB__
 	int TotOutElem = lenRelaxStatusParamArray + 1;
-	double *TotOutArray = new double[TotOutElem];
-	if(TotOutArray == 0) { ErrorMessage("Radia::Error900"); return;}
-	double *t = TotOutArray;
+	std::vector<double> TotOutArray;
+	TotOutArray.resize(TotOutElem);
+	double *t = TotOutArray.data();
 	double *tRelaxStatusParamArray = RelaxStatusParamArray;
 	for(int i=0; i<lenRelaxStatusParamArray; i++) *(t++) = *(tRelaxStatusParamArray++);
 	*t = ActualIterNum;
 
 	int Dims[] = { TotOutElem};
-	MultiDimArrayOfDouble(TotOutArray, Dims, 1);
+	MultiDimArrayOfDouble(TotOutArray.data(), Dims, 1);
 #endif
 }
 


### PR DESCRIPTION
`TotOutArray` was not properly deallocated. This PR changes the code to use `std::vector`, which is a more idiomatic way to handle dynamically sized arrays, and it automatically manages the memory.

If the memory allocation fails, an exception is thrown. (But: C++ code is almost always written with the assumption that memory allocations do not fail. It is very hard to write programs that use dynamic memory allocation and that work when memory allocations fail. It is more common to avoid dynamic memory allocation altogether if that is a concern.)

The `.resize()` call will zero-initialize the vector, which carries a performance penalty. This performance penalty will be tiny if the vector is small enough to fit on a cache page aka 4K. If you worry about this, it is possible to use `unique_ptr` instead of `vector`.

I found this with Address Sanitizer. The change removes the warning and seems to work. The change is tested on Linux/Clang only.